### PR TITLE
feat: 커밋 형식 변경 및 메시지 검증을 위한 한국어 포맷터 추가 (#23)

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,1 @@
-npx --no -- commitlint --edit $1
+npx --no -- commitlint --edit $1 --format ./scripts/commitlint-formatter-korean.js

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,9 +1,27 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
+  // 헤더 파싱 규칙을 커스터마이즈하여 "type(scope): subject (#123)" 형태를 강제
+  parserPreset: {
+    parserOpts: {
+      // type + optional scope + subject + required trailing issue number in parentheses
+      // e.g. "feat(scope): subject (#123)"
+      // subject는 소문자/숫자/공백/일부 구두점/한글만 허용(대문자 차단)
+      headerPattern: /^(feat|fix|refac|test|chore|docs)(?:\(([a-z0-9_-]+)\))?: ([a-z0-9 가-힣_\-,:()\[\]]+) \(#\d+\)$/u,
+      headerPatternFlags: 'u',
+      headerCorrespondence: ['type', 'scope', 'subject']
+    }
+  },
   rules: {
     'header-max-length': [2, 'always', 72],
+    // 헤더 전체 대문자 금지(보다 강한 방어선)
+    'header-case': [2, 'always', 'lower-case'],
     'type-case': [2, 'always', 'lower-case'],
+    'scope-case': [2, 'always', 'lower-case'],
+    // 제목(Subject)에 대문자 사용 금지
+    'subject-case': [2, 'always', ['lower-case']],
     'subject-max-length': [2, 'always', 50],
     'subject-full-stop': [2, 'never', '.'],
-  },
+    // 허용 타입을 명시(프로젝트 사용 패턴 반영)
+    'type-enum': [2, 'always', ['feat', 'fix', 'refac', 'test', 'chore', 'docs']]
+  }
 };

--- a/scripts/commitlint-formatter-korean.js
+++ b/scripts/commitlint-formatter-korean.js
@@ -1,0 +1,61 @@
+// 커스텀 커밋lint 포매터 (한국어)
+// 사용법: commitlint --format ./scripts/commitlint-formatter-korean.js
+
+const RULE_HINTS = {
+  'header-max-length': '헤더(첫 줄)는 72자 이하여야 합니다.',
+  'type-case': 'type은 소문자여야 합니다. 예) feat, fix, docs',
+  'scope-case': 'scope는 소문자/숫자/하이픈/언더스코어만 허용합니다.',
+  'subject-max-length': '제목(subject)은 50자 이하여야 합니다.',
+  'subject-full-stop': '제목(subject) 끝에 마침표(.)를 사용하지 않습니다.',
+  'subject-case': '제목(subject)은 소문자여야 합니다.',
+  'type-enum': 'type은 feat|fix|refac|test|chore|docs 중 하나여야 합니다.',
+};
+
+function formatIssues(issues = []) {
+  if (!issues.length) return '';
+  return issues
+    .map((i, idx) => {
+      const name = i.name || i.rule || '규칙 위반';
+      const hint = RULE_HINTS[name];
+      const detail = i.message || '';
+      const msg = hint ? `- [${name}] ${hint}\n    └ 상세: ${detail}` : `- [${name}] ${detail}`;
+      return `${idx + 1}. ${msg}`;
+    })
+    .join('\n');
+}
+
+module.exports = (report) => {
+  try {
+    const results = report && report.results ? report.results : [];
+    const result = results[0] || {};
+    const { valid, errors = [], warnings = [], input = '' } = result;
+
+    if (valid) {
+      return `✅ 커밋 메시지 검증 통과\n`;
+    }
+
+    const lines = [];
+    lines.push('❌ 커밋 메시지 규칙을 위반했습니다.');
+    if (input) {
+      lines.push(`입력된 메시지: "${input}"`);
+    }
+    if (errors.length) {
+      lines.push('\n[오류] 다음 항목을 수정해주세요:');
+      lines.push(formatIssues(errors));
+    }
+    if (warnings.length) {
+      lines.push('\n[경고] 참고하세요:');
+      lines.push(formatIssues(warnings));
+    }
+
+    lines.push('\n형식 가이드:');
+    lines.push('  type(scope): subject (#123)');
+    lines.push('예시:');
+    lines.push('  feat(auth): 로그인 실패 처리 추가 (#456)');
+
+    return lines.join('\n') + '\n';
+  } catch (e) {
+    return `❌ 커밋 메시지 포맷터 오류: ${e.message}\n`;
+  }
+};
+


### PR DESCRIPTION
## 요약
- 커밋lint 포맷터를 추가하여 한국어로 규칙 위반을 안내
- 커밋 메시지 형식을 "type(scope): subject (#123)"으로 강제
- `.husky/commit-msg` 스크립트에 커스텀 포맷터 적용
- `commitlint.config.js`에 헤더 패턴 및 규칙 강화 설정 추가

## 관련 이슈
- Closes #23 

